### PR TITLE
fix(cleanup): liveness-based GC for launch-meta

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -1,24 +1,49 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
+
+	"github.com/YuujiKamura/deckpilot/daemon"
 )
 
-// Cleanup sweeps deckpilot's per-session artefact directories and
-// removes files older than --days (default 3, matching the project's
-// 3-day-retention convention shared with the original Gemini-driven
-// cleanup design).
+// cleanupListSessions is the daemon LIST RPC seam. Tests swap this to
+// inject "alive session" sets or simulate daemon-down conditions for
+// the launch-meta liveness GC. This is intentionally a daemon-RPC
+// seam, separate from the paths.go filesystem/clock seams: paths.go
+// owns *where* artefacts live, this owns *who is alive*.
+var cleanupListSessions = daemon.DaemonList
+
+// Cleanup sweeps deckpilot's per-session artefact directories.
 //
-// Two directories are swept in one pass:
-//   - ~/.deckpilot/hang-dumps/         (snapshot dumps from hang-detect)
-//   - ~/.deckpilot/launch-meta/        (per-session launch metadata)
+// Two directories are swept in one pass, with deliberately different
+// retention models:
 //
-// Both contain only sanitized session-name-derived filenames, so
-// blanket age-based GC is safe; nothing in either tree is intended to
-// be edited by hand.
+//   - ~/.deckpilot/hang-dumps/   : age-based GC (default --days 3).
+//     These are operational evidence of past hangs; the value is the
+//     audit trail, not session liveness, so a fixed retention window
+//     is the right policy.
+//
+//   - ~/.deckpilot/launch-meta/  : liveness-based GC. A launch-meta
+//     file's lifetime is the *session*'s lifetime — if `deckpilot
+//     resume` or `hang-detect snapshot` can still target the session,
+//     the meta record must still exist. Age is irrelevant: a
+//     long-running session legitimately keeps its meta for weeks.
+//     Issue #29: the previous age-based sweep silently broke resume
+//     for any session older than 3 days. We now ask the daemon for
+//     the live session list and only delete meta files whose session
+//     name is NOT in that list. If the daemon LIST call fails for any
+//     reason (daemon down, IPC error, malformed JSON), we delete
+//     nothing — a conservative no-op is always safer than wrongly
+//     evicting a live session's resume metadata.
+//
+// The 3-day retention policy in the project memory file applies to
+// hang-dumps (and any future age-based artefact dir). launch-meta is
+// a separate concept with a separate, liveness-based policy.
 func Cleanup(args []string) {
 	maxAge := 3 * 24 * time.Hour
 	dryRun := false
@@ -35,32 +60,40 @@ func Cleanup(args []string) {
 	}
 
 	now := deckpilotNow()
-	totals := []struct {
-		label string
-		dir   string
-	}{
-		{"hang dumps", hangDumpsDir()},
-		{"launch-meta", launchMetaDir()},
+
+	// 1. hang-dumps: age-based sweep (unchanged policy).
+	hdDir := hangDumpsDir()
+	removed, missing := sweepDir(hdDir, maxAge, now, dryRun)
+	switch {
+	case missing:
+		fmt.Printf("No hang dumps directory at %s. Nothing to clean.\n", hdDir)
+	case dryRun:
+		// sweepDir already printed per-file lines.
+	default:
+		fmt.Printf("Cleaned up %d old hang dumps from %s\n", removed, hdDir)
 	}
 
-	for _, t := range totals {
-		removed, missing := sweepDir(t.dir, maxAge, now, dryRun)
-		switch {
-		case missing:
-			fmt.Printf("No %s directory at %s. Nothing to clean.\n", t.label, t.dir)
-		case dryRun:
-			// sweepDir already printed per-file lines for dry-run.
-		default:
-			fmt.Printf("Cleaned up %d old %s from %s\n", removed, t.label, t.dir)
-		}
+	// 2. launch-meta: liveness-based sweep.
+	lmDir := launchMetaDir()
+	removed, missing, abort := sweepLaunchMetaByLiveness(lmDir, dryRun)
+	switch {
+	case missing:
+		fmt.Printf("No launch-meta directory at %s. Nothing to clean.\n", lmDir)
+	case abort:
+		fmt.Printf("Skipped launch-meta sweep at %s: could not query daemon for live sessions (conservative no-op).\n", lmDir)
+	case dryRun:
+		// sweepLaunchMetaByLiveness already printed per-file lines.
+	default:
+		fmt.Printf("Cleaned up %d dead launch-meta entries from %s\n", removed, lmDir)
 	}
 }
 
 // sweepDir deletes files in dir whose mtime is older than maxAge from
-// now. Returns the number of files removed and a flag indicating the
-// directory itself was missing (a clean-no-op, not an error). Errors
-// reading individual entries are logged and skipped — one corrupt
-// file must not block the rest of the sweep.
+// now. Used by the hang-dumps age-based sweep. Returns the number of
+// files removed and a flag indicating the directory itself was
+// missing (a clean no-op, not an error). Errors reading individual
+// entries are logged and skipped — one corrupt file must not block
+// the rest of the sweep.
 func sweepDir(dir string, maxAge time.Duration, now time.Time, dryRun bool) (removed int, missing bool) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
@@ -94,4 +127,76 @@ func sweepDir(dir string, maxAge time.Duration, now time.Time, dryRun bool) (rem
 		removed++
 	}
 	return removed, false
+}
+
+// sweepLaunchMetaByLiveness deletes launch-meta JSON files whose
+// session name does NOT appear in the daemon's live session LIST.
+// Files are stored as <sanitized-session-name>.json (see
+// launchmeta.go), so we strip the .json suffix to derive the session
+// key for comparison.
+//
+// If the daemon LIST call fails (daemon down, IPC error, malformed
+// JSON), `abort` is set and no deletions happen. This conservative
+// no-op prevents a transient IPC failure from wiping resume metadata
+// for every live session.
+//
+// `missing` indicates the launch-meta directory itself does not yet
+// exist (clean install case) and is not an error.
+func sweepLaunchMetaByLiveness(dir string, dryRun bool) (removed int, missing bool, abort bool) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, true, false
+		}
+		fmt.Fprintf(os.Stderr, "cleanup: read %s: %v\n", dir, err)
+		return 0, false, false
+	}
+
+	// Query the daemon for live sessions BEFORE touching anything.
+	// Any failure here is fatal to this sweep — we will not guess.
+	raw, err := cleanupListSessions()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup: launch-meta liveness query failed: %v\n", err)
+		return 0, false, true
+	}
+	var sessions []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(raw), &sessions); err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup: launch-meta liveness query bad json: %v\n", err)
+		return 0, false, true
+	}
+	live := make(map[string]struct{}, len(sessions))
+	for _, s := range sessions {
+		// Match the on-disk filename convention used by
+		// launchmeta.go (sanitizeFilename of the session name).
+		live[sanitizeFilename(s.Name)] = struct{}{}
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		if !strings.HasSuffix(name, ".json") {
+			// Don't touch unexpected files — could be a future
+			// artefact format the operator added by hand.
+			continue
+		}
+		key := strings.TrimSuffix(name, ".json")
+		if _, alive := live[key]; alive {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if dryRun {
+			fmt.Printf("[dry-run] would delete dead launch-meta: %s\n", path)
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to delete %s: %v\n", path, err)
+			continue
+		}
+		removed++
+	}
+	return removed, false, false
 }

--- a/cmd/cleanup_test.go
+++ b/cmd/cleanup_test.go
@@ -1,94 +1,210 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
 
-// TestCleanup_SweepsBothDirectoriesByAge pins the 3-day retention
-// policy across hang-dumps and launch-meta. Files older than the
-// threshold are removed; recent files survive.
-func TestCleanup_SweepsBothDirectoriesByAge(t *testing.T) {
-	tempHome := t.TempDir()
+// withCleanupSeams installs all four seams (home, clock, daemon LIST)
+// and restores them on test cleanup. Centralizes the boilerplate so
+// individual tests stay focused on the policy assertion.
+func withCleanupSeams(t *testing.T, tempHome string, now time.Time, listFn func() (string, error)) {
+	t.Helper()
 	oldHome := deckpilotUserHome
 	oldNow := deckpilotNow
+	oldList := cleanupListSessions
 	t.Cleanup(func() {
 		deckpilotUserHome = oldHome
 		deckpilotNow = oldNow
+		cleanupListSessions = oldList
 	})
 	deckpilotUserHome = func() (string, error) { return tempHome, nil }
-	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
 	deckpilotNow = func() time.Time { return now }
+	cleanupListSessions = listFn
+}
 
-	// Lay down 4 files: stale + fresh in each of the two dirs.
-	for _, dir := range []string{hangDumpsDir(), launchMetaDir()} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", dir, err)
-		}
-		stale := filepath.Join(dir, "old.log")
-		fresh := filepath.Join(dir, "new.log")
-		if err := os.WriteFile(stale, []byte("x"), 0o644); err != nil {
+// TestCleanup_HangDumpsSweptByAge pins the 3-day age-based retention
+// for hang-dumps. This is the operational-evidence directory and its
+// retention policy is age, not liveness.
+func TestCleanup_HangDumpsSweptByAge(t *testing.T) {
+	tempHome := t.TempDir()
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	// Daemon returns empty session list — irrelevant to hang-dumps.
+	withCleanupSeams(t, tempHome, now, func() (string, error) { return "[]", nil })
+
+	dir := hangDumpsDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	stale := filepath.Join(dir, "old.log")
+	fresh := filepath.Join(dir, "new.log")
+	if err := os.WriteFile(stale, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fresh, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fiveDaysAgo := now.Add(-5 * 24 * time.Hour)
+	oneHourAgo := now.Add(-1 * time.Hour)
+	if err := os.Chtimes(stale, fiveDaysAgo, fiveDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(fresh, oneHourAgo, oneHourAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	Cleanup(nil)
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale hang-dump should have been deleted, err=%v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("fresh hang-dump must survive, err=%v", err)
+	}
+}
+
+// TestCleanup_LaunchMetaLiveSessionSurvivesAge pins the core fix for
+// issue #29: a launch-meta file for a session that the daemon
+// reports as live must NOT be deleted, regardless of how old its
+// mtime is. A 30-day-old long-running session is fully legitimate.
+func TestCleanup_LaunchMetaLiveSessionSurvivesAge(t *testing.T) {
+	tempHome := t.TempDir()
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	// Daemon reports ghostty-X as alive.
+	withCleanupSeams(t, tempHome, now, func() (string, error) {
+		return `[{"name":"ghostty-X","pid":1234,"app_runtime":"win32","status":"running","uptime":"30d"}]`, nil
+	})
+
+	dir := launchMetaDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	live := filepath.Join(dir, "ghostty-X.json")
+	if err := os.WriteFile(live, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	thirtyDaysAgo := now.Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(live, thirtyDaysAgo, thirtyDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	Cleanup(nil)
+
+	if _, err := os.Stat(live); err != nil {
+		t.Errorf("live session's launch-meta must survive regardless of age, err=%v", err)
+	}
+}
+
+// TestCleanup_LaunchMetaDeadSessionDeletedRegardlessOfAge pins the
+// other half of the liveness policy: a session not in the daemon's
+// LIST must be evicted, even if its mtime is fresh.
+func TestCleanup_LaunchMetaDeadSessionDeletedRegardlessOfAge(t *testing.T) {
+	tempHome := t.TempDir()
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	// Daemon reports only ghostty-X as alive; ghostty-DEAD is not.
+	withCleanupSeams(t, tempHome, now, func() (string, error) {
+		return `[{"name":"ghostty-X","pid":1,"app_runtime":"win32","status":"running","uptime":"1m"}]`, nil
+	})
+
+	dir := launchMetaDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dead := filepath.Join(dir, "ghostty-DEAD.json")
+	if err := os.WriteFile(dead, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Even fresh files get evicted if the session is dead.
+	oneMinAgo := now.Add(-1 * time.Minute)
+	if err := os.Chtimes(dead, oneMinAgo, oneMinAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	Cleanup(nil)
+
+	if _, err := os.Stat(dead); !os.IsNotExist(err) {
+		t.Errorf("dead session's launch-meta must be deleted, err=%v", err)
+	}
+}
+
+// TestCleanup_LaunchMetaDaemonDownIsNoOp pins the conservative
+// behavior: if we cannot determine liveness, we delete nothing. A
+// transient daemon-down condition must never wipe resume metadata
+// for every live session.
+func TestCleanup_LaunchMetaDaemonDownIsNoOp(t *testing.T) {
+	tempHome := t.TempDir()
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	withCleanupSeams(t, tempHome, now, func() (string, error) {
+		return "", fmt.Errorf("daemon: connection refused")
+	})
+
+	dir := launchMetaDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Make every file ancient — under the old age-based policy they
+	// would all be wiped. Under the new policy with daemon down, all
+	// must survive.
+	for _, name := range []string{"ghostty-A.json", "ghostty-B.json", "ghostty-C.json"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(fresh, []byte("x"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		// 5 days old vs 1 hour old.
-		fiveDaysAgo := now.Add(-5 * 24 * time.Hour)
-		oneHourAgo := now.Add(-1 * time.Hour)
-		if err := os.Chtimes(stale, fiveDaysAgo, fiveDaysAgo); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chtimes(fresh, oneHourAgo, oneHourAgo); err != nil {
+		ancient := now.Add(-30 * 24 * time.Hour)
+		if err := os.Chtimes(path, ancient, ancient); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	Cleanup(nil) // default --days 3
+	Cleanup(nil)
 
-	for _, dir := range []string{hangDumpsDir(), launchMetaDir()} {
-		if _, err := os.Stat(filepath.Join(dir, "old.log")); !os.IsNotExist(err) {
-			t.Errorf("stale file in %s should have been deleted, err=%v", dir, err)
-		}
-		if _, err := os.Stat(filepath.Join(dir, "new.log")); err != nil {
-			t.Errorf("fresh file in %s must survive, err=%v", dir, err)
+	for _, name := range []string{"ghostty-A.json", "ghostty-B.json", "ghostty-C.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("daemon-down must not delete %s, err=%v", name, err)
 		}
 	}
 }
 
 // TestCleanup_DryRunDeletesNothing pins that --dry-run never touches
-// the filesystem — the policy is "always reportable, never silently
-// destructive when the operator asked to see first".
+// the filesystem — neither the age-based hang-dumps sweep nor the
+// liveness-based launch-meta sweep.
 func TestCleanup_DryRunDeletesNothing(t *testing.T) {
 	tempHome := t.TempDir()
-	oldHome := deckpilotUserHome
-	oldNow := deckpilotNow
-	t.Cleanup(func() {
-		deckpilotUserHome = oldHome
-		deckpilotNow = oldNow
-	})
-	deckpilotUserHome = func() (string, error) { return tempHome, nil }
 	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
-	deckpilotNow = func() time.Time { return now }
+	// Daemon says "no live sessions" — would normally evict
+	// everything in launch-meta, but --dry-run must hold.
+	withCleanupSeams(t, tempHome, now, func() (string, error) { return "[]", nil })
 
-	dir := hangDumpsDir()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	hdDir := hangDumpsDir()
+	lmDir := launchMetaDir()
+	if err := os.MkdirAll(hdDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	stale := filepath.Join(dir, "old.log")
-	if err := os.WriteFile(stale, []byte("x"), 0o644); err != nil {
+	if err := os.MkdirAll(lmDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chtimes(stale, now.Add(-30*24*time.Hour), now.Add(-30*24*time.Hour)); err != nil {
-		t.Fatal(err)
+	hdStale := filepath.Join(hdDir, "old.log")
+	lmDead := filepath.Join(lmDir, "ghostty-DEAD.json")
+	for _, p := range []string{hdStale, lmDead} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ancient := now.Add(-30 * 24 * time.Hour)
+		if err := os.Chtimes(p, ancient, ancient); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	Cleanup([]string{"--dry-run"})
 
-	if _, err := os.Stat(stale); err != nil {
-		t.Errorf("--dry-run must not delete: %v", err)
+	if _, err := os.Stat(hdStale); err != nil {
+		t.Errorf("--dry-run must not delete hang-dump: %v", err)
+	}
+	if _, err := os.Stat(lmDead); err != nil {
+		t.Errorf("--dry-run must not delete dead launch-meta: %v", err)
 	}
 }
 
@@ -97,9 +213,8 @@ func TestCleanup_DryRunDeletesNothing(t *testing.T) {
 // on a brand-new install is the most common first call.
 func TestCleanup_MissingDirIsNoError(t *testing.T) {
 	tempHome := t.TempDir()
-	oldHome := deckpilotUserHome
-	t.Cleanup(func() { deckpilotUserHome = oldHome })
-	deckpilotUserHome = func() (string, error) { return tempHome, nil }
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	withCleanupSeams(t, tempHome, now, func() (string, error) { return "[]", nil })
 
 	// No directories created. Should print "No ... directory" and
 	// return cleanly.


### PR DESCRIPTION
Closes #29.

## Problem
`deckpilot cleanup` (default `--days 3`) deleted launch-meta files for **live, long-running sessions** because the sweep was purely mtime-based. launch-meta lifetime should match **session lifetime**, not a fixed retention window — losing it silently breaks `deckpilot resume` and `hang-detect snapshot`.

## Fix
Split `Cleanup()` into two policy lanes:

| Directory | Policy | Why |
|---|---|---|
| `~/.deckpilot/hang-dumps/` | age-based, default `--days 3` (unchanged) | operational evidence; fixed retention is correct |
| `~/.deckpilot/launch-meta/` | **liveness-based, age irrelevant** | tied to session lifetime |

Liveness lane: query `daemon.DaemonList()` for live session names; delete only meta files whose session is **not** in the live set. If the LIST RPC fails for any reason (daemon down, IPC error, malformed JSON), **abort the sweep** with a conservative no-op so a transient failure cannot wipe resume metadata for every live session.

Adds `cleanupListSessions` package var as a daemon-RPC seam (distinct from the existing `paths.go` filesystem/clock seams) so tests can inject live-session sets and simulate IPC failure.

## Tests (`cmd/cleanup_test.go`)
- `TestCleanup_HangDumpsSweptByAge` — hang-dumps still age-GC'd independently
- `TestCleanup_LaunchMetaLiveSessionSurvivesAge` — 30-day-old live session's meta survives
- `TestCleanup_LaunchMetaDeadSessionDeletedRegardlessOfAge` — dead session's fresh meta deleted
- `TestCleanup_LaunchMetaDaemonDownIsNoOp` — IPC failure deletes nothing
- `TestCleanup_DryRunDeletesNothing` — `--dry-run` holds across both lanes
- `TestCleanup_MissingDirIsNoError` — clean install no-op

## Verification
- `go build ./...` clean
- `go test ./... -count=1 -race` all green

## Memory updated
`~/.claude/projects/C--Users-yuuji-deckpilot/memory/deckpilot_cleanup_policy.md` documents the two-lane policy: per-dir retention flags remain forbidden; new artefact dirs pick age-based or liveness-based at registration time.