### PR TITLE
feat(launch): redact prompt persistence + 0o600 file mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,7 +88,7 @@ codex-02    wt        active
 ### `launch` — エージェント起動
 
 ```bash
-deckpilot launch <agent> <prompt...> [--cwd DIR]
+deckpilot launch <agent> <prompt...> [--cwd DIR] [--no-meta-prompt]
 ```
 
 Ghostty ウィンドウを新規起動し、エージェントの準備完了を待ってからプロンプトを送信する。セッション名を stdout に出力するのでスクリプトから利用可能。
@@ -100,6 +100,26 @@ Ghostty ウィンドウを新規起動し、エージェントの準備完了を
 | haiku   | `claude --model haiku`                   | `>`          |
 | codex   | `codex --full-auto`                      | `›`          |
 | gemini  | `gemini`                                 | `>`          |
+
+#### Prompt 永続化と `--no-meta-prompt`
+
+既定では `deckpilot launch` は prompt を以下の 2 箇所に平文で記録する。ハングしたセッションを resume するための情報源:
+
+- `~/.deckpilot/launch-meta/<session>.json` の `prompt` フィールド (hang-detect snapshot が `# resume_command:` 行を組み立てる際に参照)
+- `~/.deckpilot/hang-dumps/<ts>-<session>.log` の `# original_prompt:` / `# resume_command:` 行 (実際にハングした時にのみ生成)
+
+両ファイルは `0o600` で書き出される。POSIX ホストでは他ユーザーから読めない設定だが、NTFS は Unix mode bit から ACL を導出しないため、Windows ではあくまで「意図表明」として機能する。共有マシンで untrusted user がいる場合はホームディレクトリ自体の Windows ACL で守ること。
+
+prompt 自体にトークン / API キー / シークレットを含めるケースでは `--no-meta-prompt` で永続化を完全に抑止できる:
+
+```bash
+deckpilot launch claude --no-meta-prompt "deploy with $TOKEN"
+```
+
+フラグ指定時の挙動:
+
+- launch-meta JSON は `"prompt": ""` と `"redacted": true` だけが残り、prompt 本文は一切ディスクに到達しない。
+- hang-dump は `# original_prompt: <redacted>` を出力し、`# resume_command:` の prompt 引数は `<REDACTED — supply manually>` という placeholder に置換される。operator は再起動時に手で prompt を入れ直す必要がある。
 
 ### `watch` — セッション監視（表示専用）
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ codex-02    wt        active
 ### `launch`  EStart an agent
 
 ```bash
-deckpilot launch <agent> <prompt...> [--cwd DIR]
+deckpilot launch <agent> <prompt...> [--cwd DIR] [--no-meta-prompt]
 ```
 
 Starts a new Ghostty window, waits for the agent to be ready, then sends the prompt. Prints the session name to stdout for use in scripts.
@@ -100,6 +100,26 @@ Starts a new Ghostty window, waits for the agent to be ready, then sends the pro
 | haiku  | `claude --model haiku`                   | `>`          |
 | codex  | `codex --full-auto`                      | `›`          |
 | gemini | `gemini`                                 | `>`          |
+
+#### Prompt persistence and `--no-meta-prompt`
+
+By default, `deckpilot launch` records the prompt verbatim in two places so a hung session can be reconstructed without operator spelunking:
+
+- `~/.deckpilot/launch-meta/<session>.json` — the `prompt` field (read by hang-detect's snapshot action to synthesise a `# resume_command:` line).
+- `~/.deckpilot/hang-dumps/<ts>-<session>.log` — the `# original_prompt:` and `# resume_command:` lines, only written when the session actually hangs.
+
+Both files are created with mode `0o600` so other accounts on shared POSIX hosts cannot read them. NTFS does not derive ACLs from the Unix mode bits, so on Windows the mode is intent rather than enforcement — protect the home directory through normal Windows ACLs if untrusted users share the box.
+
+If the prompt itself contains tokens / API keys / other secrets, pass `--no-meta-prompt` to suppress prompt persistence entirely:
+
+```bash
+deckpilot launch claude --no-meta-prompt "deploy with $TOKEN"
+```
+
+When the flag is set:
+
+- The launch-meta JSON stores `"prompt": ""` and `"redacted": true` — the prompt body never reaches disk.
+- A subsequent hang-dump emits `# original_prompt: <redacted>` and a `# resume_command:` whose prompt argument is the literal placeholder `<REDACTED — supply manually>`. The operator must retype the real prompt when respawning.
 
 ### `watch`  EMonitor sessions (view-only)
 
@@ -149,52 +169,52 @@ Stop with Ctrl+C.
 
 ## Caller Identification
 
-`show` でセチE��ョン名を省略できるよう、呼び出し�Eターミナルを�E動識別する、E
-**優先頁E��E**
-1. `DECKPILOT_CALLER` 環墁E��数�E��E示持E��！E2. `WT_SESSION`  EWindows Terminal のタチEペイン GUID ↁE`wt:<guid>`
+`show` でセチE��ョン名を省略できるよう、呼び出し�Eターミナルを�E動識別する、E
+**優先頁E��E**
+1. `DECKPILOT_CALLER` 環墁E��数�E��E示持E��！E2. `WT_SESSION`  EWindows Terminal のタチEペイン GUID ↁE`wt:<guid>`
 3. `GHOSTTY_SESSION` ↁE`ghostty:<guid>`
-4. PPID�E�親プロセス ID�E��E `pid:<ppid>`
+4. PPID�E�親プロセス ID�E��E `pid:<ppid>`
 5. `default` フォールバック
 
-`send` 実行時に `lastUsed[caller] = session` を記録し、以降�E `show` で自動解決する、E
-## セチE��ョン検�E
+`send` 実行時に `lastUsed[caller] = session` を記録し、以降�E `show` で自動解決する、E
+## セチE��ョン検�E
 
-2 段階�Eフォールバック:
+2 段階�Eフォールバック:
 
-### 1. .session ファイル�E�優先！E
+### 1. .session ファイル�E�優先！E
 ```
 %LOCALAPPDATA%\ghostty\control-plane\{winui3,win32,web}\sessions\*.session
 %LOCALAPPDATA%\WindowsTerminal\control-plane\winui3\sessions\*.session
 ```
 
-key=value 形式で `session_name`, `pipe_path`, `pid`, `hwnd` を保持。�Eロセス生存と pipe 応答を検証し、不正なファイルは自動削除。Windows Terminal の場合�E `wt-sidecar` がこのファイルを生成する、E
-### 2. プロセス探索�E�フォールバック�E�E
-Windows ToolHelp32 API で `ghostty.exe` を�E挙し、既知のパイプ命名規則 `\\.\pipe\ghostty-{runtime}-ghostty-<pid>-<pid>` を探索する、E
+key=value 形式で `session_name`, `pipe_path`, `pid`, `hwnd` を保持。�Eロセス生存と pipe 応答を検証し、不正なファイルは自動削除。Windows Terminal の場合�E `wt-sidecar` がこのファイルを生成する、E
+### 2. プロセス探索�E�フォールバック�E�E
+Windows ToolHelp32 API で `ghostty.exe` を�E挙し、既知のパイプ命名規則 `\\.\pipe\ghostty-{runtime}-ghostty-<pid>-<pid>` を探索する、E
 ## 既知の問題と対筁E
 ### Ghostty CP ドレイン問顁E
-**痁E��**: メチE��ージ送信後、Enter が消失しバチE��ァに反映されなぁE��E
-**対筁E*: 送信前後�Eバッファハッシュを比輁E��、E00ms 経過後も変化がなければ `\r` を最大 3 回リトライする、E
-### スラチE��ュコマンド�EオートコンプリーチE
-**痁E��**: `/help` 等�EスラチE��ュコマンドで最初�E Enter がオートコンプリートメニューに吸収される、E
-**対筁E*: `/` 始まり�EメチE��ージ検�E時、E00ms 後に 2 回目の Enter を�E動送信、E
-### TUI エージェント�E idle 検�E
+**痁E��**: メチE��ージ送信後、Enter が消失しバチE��ァに反映されなぁE��E
+**対筁E*: 送信前後�Eバッファハッシュを比輁E��、E00ms 経過後も変化がなければ `\r` を最大 3 回リトライする、E
+### スラチE��ュコマンド�EオートコンプリーチE
+**痁E��**: `/help` 等�EスラチE��ュコマンドで最初�E Enter がオートコンプリートメニューに吸収される、E
+**対筁E*: `/` 始まり�EメチE��ージ検�E時、E00ms 後に 2 回目の Enter を�E動送信、E
+### TUI エージェント�E idle 検�E
 
-**痁E��**: Claude Code 等�E TUI エージェント�Eカーソル点滁E��スチE�Eタスバ�E更新で常にバッファが変化し、`idle` 状態に安定しなぁE��E
-**対筁E*: `launch` では `idle` を征E��ず、エージェント固有�E Ready 斁E���E�E�E>`, `›`�E��E出現のみで準備完亁E��判定、E
+**痁E��**: Claude Code 等�E TUI エージェント�Eカーソル点滁E��スチE�Eタスバ�E更新で常にバッファが変化し、`idle` 状態に安定しなぁE��E
+**対筁E*: `launch` では `idle` を征E��ず、エージェント固有�E Ready 斁E���E�E�E>`, `›`�E��E出現のみで準備完亁E��判定、E
 ### RAW_INPUT 非対忁E
-**痁E��**: 古ぁEGhostty ビルドが `RAW_INPUT` コマンドを認識しなぁE��E
-**対筁E*: `PARSE_ERROR` 応答時に `INPUT`�E�テキストエンコード）へ自動フォールバック、E
+**痁E��**: 古ぁEGhostty ビルドが `RAW_INPUT` コマンドを認識しなぁE��E
+**対筁E*: `PARSE_ERROR` 応答時に `INPUT`�E�テキストエンコード）へ自動フォールバック、E
 ### MSYS2 パス変換
 
-**痁E��**: Git Bash 上で引数のスラチE��ュぁEWindows パスに変換される（侁E `/help` ↁE`C:/Program Files/Git/help`�E�、E
-**対筁E*: 既知のプレフィチE��スを検�Eし、�Eのパスに送E��換する、E
+**痁E��**: Git Bash 上で引数のスラチE��ュぁEWindows パスに変換される（侁E `/help` ↁE`C:/Program Files/Git/help`�E�、E
+**対筁E*: 既知のプレフィチE��スを検�Eし、�Eのパスに送E��換する、E
 ### Ghostty -e オプション
 
-**痁E��**: `ghostty -e <cmd>` がデバッグビルドで IO スレチE��エラーを起こす、E
+**痁E��**: `ghostty -e <cmd>` がデバッグビルドで IO スレチE��エラーを起こす、E
 **対筁E*: Ghostty を引数なしで起動し、シェルプロンプト出現後にコマンドを pipe 経由で入力する、E
 ## IPC プロトコル
 
-Daemon は `\\.\pipe\deckpilot-daemon` で以下�Eコマンドを受け付けめE
+Daemon は `\\.\pipe\deckpilot-daemon` で以下�Eコマンドを受け付けめE
 
 | コマンチE| 形弁E| 応筁E|
 |---------|------|------|

--- a/cmd/hangdetect.go
+++ b/cmd/hangdetect.go
@@ -425,9 +425,20 @@ func snapshotActionForSession(sessionName string) daemon.HangAction {
 			fmt.Fprintf(&hb, "# launched_agent: %s\n", meta.Agent)
 			fmt.Fprintf(&hb, "# launched_cwd: %s\n", meta.Cwd)
 			fmt.Fprintf(&hb, "# launched_at: %s\n", meta.LaunchedAt.Format(time.RFC3339))
-			fmt.Fprintf(&hb, "# original_prompt: %s\n", oneLineForHeader(meta.Prompt))
-			fmt.Fprintf(&hb, "# resume_command: deckpilot launch %s %s --cwd %s\n",
-				meta.Agent, shellQuote(meta.Prompt), shellQuote(meta.Cwd))
+			if meta.Redacted {
+				// --no-meta-prompt was active when the session
+				// launched. The prompt was never persisted, so
+				// neither the original_prompt line nor the
+				// resume_command can include it — operator must
+				// re-supply it manually when respawning.
+				fmt.Fprintln(&hb, "# original_prompt: <redacted>")
+				fmt.Fprintf(&hb, "# resume_command: deckpilot launch %s %s --cwd %s\n",
+					meta.Agent, shellQuote(RedactedPromptPlaceholder), shellQuote(meta.Cwd))
+			} else {
+				fmt.Fprintf(&hb, "# original_prompt: %s\n", oneLineForHeader(meta.Prompt))
+				fmt.Fprintf(&hb, "# resume_command: deckpilot launch %s %s --cwd %s\n",
+					meta.Agent, shellQuote(meta.Prompt), shellQuote(meta.Cwd))
+			}
 		default:
 			fmt.Fprintln(&hb, "# launched_by: external (no launch-meta record — session was not started by `deckpilot launch`)")
 			fmt.Fprintln(&hb, "# resume_hint: read the full history below to recover the in-flight task,")
@@ -467,7 +478,13 @@ func snapshotActionForSession(sessionName string) daemon.HangAction {
 			}
 		}
 
-		if err := os.WriteFile(path, []byte(hb.String()+bb.String()), 0o644); err != nil {
+		// 0o600: hang dumps embed the original prompt (when not
+		// redacted) plus the full PTY history, which can carry
+		// tokens / paths / partial answers the operator would
+		// not want world-readable. NTFS ignores Unix mode bits
+		// so on Windows this is intent rather than enforcement —
+		// see issue #30.
+		if err := os.WriteFile(path, []byte(hb.String()+bb.String()), 0o600); err != nil {
 			return fmt.Errorf("ActionSnapshot: write %s: %w", path, err)
 		}
 		return nil

--- a/cmd/hangdetect_snapshot_test.go
+++ b/cmd/hangdetect_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -253,6 +254,101 @@ func TestSnapshotActionForSession_V2NoLaunchMetaShowsExternalMarker(t *testing.T
 	}
 	if strings.Contains(string(text), "resume_command:") {
 		t.Errorf("must not synthesize a resume_command without launch-meta:\n%s", text)
+	}
+}
+
+// TestSnapshotActionForSession_V2RedactedMetaScrubsPromptAndResume is
+// the issue #30 stage-2 contract on the snapshot side: when the
+// launch-meta carries Redacted=true, the dump must NOT echo the
+// original prompt anywhere, and the resume_command must use the
+// operator-supplied placeholder so a copy-paste replay forces a
+// human to retype the secret.
+func TestSnapshotActionForSession_V2RedactedMetaScrubsPromptAndResume(t *testing.T) {
+	r := newSnapshotRig(t)
+
+	secret := "sk-ultra-secret-token-9999"
+	if err := WriteLaunchMeta(LaunchMeta{
+		SessionName: "ghostty-redact",
+		Agent:       "claude",
+		Cwd:         `C:\Users\yuuji\work`,
+		Prompt:      secret, // Will be scrubbed by WriteLaunchMeta.
+		Redacted:    true,
+		LaunchedAt:  time.Date(2026, 4, 26, 17, 30, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+
+	hangDetectDaemonListWithContext = func(context.Context) (string, error) {
+		return `[{"name":"ghostty-redact","pid":1,"pipe_path":"p","app_runtime":"winui3","status":"stalled","uptime":"5m"}]`, nil
+	}
+	hangDetectPipeTailWithContext = func(context.Context, string, int) (string, error) {
+		return "tail body\n", nil
+	}
+	hangDetectPipeHistoryWithContext = func(context.Context, string) (string, error) {
+		return "Welcome to Claude\n", nil
+	}
+
+	info := daemon.HangInfo{SessionName: "ghostty-redact", RootPID: 1}
+	if err := snapshotActionForSession("ghostty-redact")(context.Background(), info); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	body, err := os.ReadFile(r.dumpPath("ghostty-redact"))
+	if err != nil {
+		t.Fatalf("read dump: %v", err)
+	}
+	text := string(body)
+
+	if strings.Contains(text, secret) {
+		t.Fatalf("redacted dump leaked the secret prompt:\n%s", text)
+	}
+	for _, want := range []string{
+		"# launched_agent: claude",
+		`# launched_cwd: C:\Users\yuuji\work`,
+		"# original_prompt: <redacted>",
+		// resume_command must include the placeholder, not the
+		// real prompt — the operator has to re-supply it.
+		`# resume_command: deckpilot launch claude "` + RedactedPromptPlaceholder + `" --cwd "C:\Users\yuuji\work"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("dump missing %q\nfull dump:\n%s", want, text)
+		}
+	}
+}
+
+// TestSnapshotActionForSession_FileMode pins issue #30 stage-1 on the
+// hang-dump side: the snapshot file is created with 0o600 so the
+// embedded prompt + history is not world-readable. Same Windows caveat
+// as the launch-meta sibling test.
+func TestSnapshotActionForSession_FileMode(t *testing.T) {
+	r := newSnapshotRig(t)
+
+	hangDetectDaemonListWithContext = func(context.Context) (string, error) {
+		return `[{"name":"ghostty-mode","pid":1,"pipe_path":"p","app_runtime":"win32","status":"idle","uptime":"1m"}]`, nil
+	}
+	hangDetectPipeTailWithContext = func(context.Context, string, int) (string, error) {
+		return "tail\n", nil
+	}
+	hangDetectPipeHistoryWithContext = func(context.Context, string) (string, error) {
+		return "", nil
+	}
+
+	info := daemon.HangInfo{SessionName: "ghostty-mode", RootPID: 1}
+	if err := snapshotActionForSession("ghostty-mode")(context.Background(), info); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	info2, err := os.Stat(r.dumpPath("ghostty-mode"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	perm := info2.Mode().Perm()
+	if runtime.GOOS == "windows" {
+		if perm&0o400 == 0 {
+			t.Errorf("dump should be owner-readable on Windows; got %o", perm)
+		}
+	} else {
+		if perm != 0o600 {
+			t.Errorf("expected dump mode 0o600, got %o", perm)
+		}
 	}
 }
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -14,16 +14,68 @@ import (
 	"github.com/YuujiKamura/deckpilot/daemon"
 )
 
+// LaunchArgs is the parsed result of `deckpilot launch ...` flags. The
+// fields are deliberately concrete (not a flag.FlagSet) so tests can
+// exercise the parser without poking at the global flag state and so
+// the calling Launch can keep its existing fmt.Fprintln error
+// reporting style.
+type LaunchArgs struct {
+	AgentName    string
+	Prompt       string
+	Cwd          string
+	NoMetaPrompt bool
+}
+
+// ParseLaunchArgs is the args parser carved out of Launch so tests can
+// pin the --no-meta-prompt / --cwd / prompt-collection rules without
+// going through os.Exit. Returns (parsed, "") on success, or
+// (zero, error message) on a usage error. The caller decides whether
+// to write the error to stderr and exit.
+//
+// args is the slice after the subcommand name (i.e. `launch <agent>
+// <prompt...>` minus the `launch` token).
+func ParseLaunchArgs(args []string, defaultCwd string) (LaunchArgs, string) {
+	if len(args) < 1 {
+		return LaunchArgs{}, "usage: deckpilot launch <agent> <prompt...> [--cwd DIR] [--no-meta-prompt]"
+	}
+	out := LaunchArgs{
+		AgentName: args[0],
+		Cwd:       defaultCwd,
+	}
+	var promptParts []string
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--cwd":
+			if i+1 >= len(args) {
+				return LaunchArgs{}, "--cwd requires a value"
+			}
+			out.Cwd = args[i+1]
+			i++
+		case "--no-meta-prompt":
+			out.NoMetaPrompt = true
+		default:
+			promptParts = append(promptParts, args[i])
+		}
+	}
+	out.Prompt = strings.Join(promptParts, " ")
+	if out.Prompt == "" {
+		return LaunchArgs{}, "usage: deckpilot launch <agent> <prompt...> [--cwd DIR] [--no-meta-prompt]"
+	}
+	return out, ""
+}
+
 // Launch starts a Ghostty window running the specified agent, waits for the
 // session to appear, handles trust confirmation, waits for ready, and sends
 // the prompt. Prints the session name on success.
 func Launch(args []string) {
-	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: deckpilot launch <agent> <prompt...> [--cwd DIR]")
+	cwdDefault, _ := os.Getwd()
+	parsed, errMsg := ParseLaunchArgs(args, cwdDefault)
+	if errMsg != "" {
+		fmt.Fprintln(os.Stderr, errMsg)
 		os.Exit(1)
 	}
 
-	agentName := args[0]
+	agentName := parsed.AgentName
 	agent, ok := agents[agentName]
 	if !ok {
 		names := make([]string, 0, len(agents))
@@ -34,18 +86,9 @@ func Launch(args []string) {
 		os.Exit(1)
 	}
 
-	// Parse --cwd flag and collect prompt
-	cwd, _ := os.Getwd()
-	var promptParts []string
-	for i := 1; i < len(args); i++ {
-		if args[i] == "--cwd" && i+1 < len(args) {
-			cwd = args[i+1]
-			i++
-		} else {
-			promptParts = append(promptParts, args[i])
-		}
-	}
-	prompt := strings.Join(promptParts, " ")
+	cwd := parsed.Cwd
+	prompt := parsed.Prompt
+	noMetaPrompt := parsed.NoMetaPrompt
 
 	if err := daemon.EnsureRunning(); err != nil {
 		fmt.Fprintf(os.Stderr, "daemon: %v\n", err)
@@ -101,6 +144,7 @@ func Launch(args []string) {
 		Agent:       agentName,
 		Cwd:         cwd,
 		Prompt:      prompt,
+		Redacted:    noMetaPrompt,
 	}); metaErr != nil {
 		fmt.Fprintf(os.Stderr, "launch-meta: %v (continuing)\n", metaErr)
 	}

--- a/cmd/launchmeta.go
+++ b/cmd/launchmeta.go
@@ -19,13 +19,26 @@ import (
 // daemon's session map is in-memory) and avoids widening the IPC
 // surface. A missing file is treated as "session was not started by
 // deckpilot launch" — snapshot v2 falls back to the inferred agent.
+//
+// When Redacted is true the Prompt field is intentionally blanked
+// before persistence so any tokens / API keys the operator pasted
+// never hit disk. The snapshot path uses the flag to swap the
+// `# original_prompt:` and `# resume_command:` lines for
+// operator-supplied placeholders.
 type LaunchMeta struct {
 	SessionName string    `json:"session_name"`
 	Agent       string    `json:"agent"`
 	Cwd         string    `json:"cwd"`
 	Prompt      string    `json:"prompt"`
 	LaunchedAt  time.Time `json:"launched_at"`
+	Redacted    bool      `json:"redacted,omitempty"`
 }
+
+// RedactedPromptPlaceholder is the literal string snapshot v2 emits
+// in place of the captured prompt when the launch was redacted. Kept
+// as a constant so tests and the snapshot path stay in lockstep with
+// any future wording change.
+const RedactedPromptPlaceholder = "<REDACTED — supply manually>"
 
 func launchMetaPath(sessionName string) string {
 	return filepath.Join(launchMetaDir(), sanitizeFilename(sessionName)+".json")
@@ -39,6 +52,14 @@ func WriteLaunchMeta(meta LaunchMeta) error {
 	if meta.LaunchedAt.IsZero() {
 		meta.LaunchedAt = deckpilotNow()
 	}
+	// Strip the prompt unconditionally when redacted so an operator
+	// inspecting the JSON sees nothing sensitive — even reading back
+	// the meta later (ReadLaunchMeta) yields an empty Prompt and the
+	// Redacted=true flag, which is enough for snapshot v2 to swap
+	// in the placeholder.
+	if meta.Redacted {
+		meta.Prompt = ""
+	}
 	dir := launchMetaDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("launch-meta mkdir: %w", err)
@@ -48,7 +69,12 @@ func WriteLaunchMeta(meta LaunchMeta) error {
 		return fmt.Errorf("launch-meta marshal: %w", err)
 	}
 	path := launchMetaPath(meta.SessionName)
-	if err := os.WriteFile(path, body, 0o644); err != nil {
+	// 0o600: the file may carry the prompt verbatim (when not
+	// --no-meta-prompt) plus cwd / agent tied to the operator's
+	// session. POSIX hosts get the obvious narrowing; on NTFS this
+	// is mostly an intent marker because Windows ACLs are not
+	// derived from the Unix mode bits — see issue #30.
+	if err := os.WriteFile(path, body, 0o600); err != nil {
 		return fmt.Errorf("launch-meta write %s: %w", path, err)
 	}
 	return nil

--- a/cmd/launchmeta_test.go
+++ b/cmd/launchmeta_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -124,6 +125,182 @@ func TestShellQuote(t *testing.T) {
 		if got := shellQuote(c.in); got != c.want {
 			t.Errorf("shellQuote(%q)=%q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestWriteLaunchMeta_FileMode pins issue #30 stage-1: every
+// launch-meta JSON is created with 0o600 so secrets pasted into the
+// prompt cannot be read by other accounts on shared POSIX hosts. On
+// Windows the OS does not derive ACLs from the Unix bits, so the
+// assertion is the intent (mode argument actually passed to
+// os.WriteFile) — we verify it on POSIX and just smoke-test on
+// Windows that the file is at least owner-readable.
+func TestWriteLaunchMeta_FileMode(t *testing.T) {
+	home := withMetaHome(t)
+	if err := WriteLaunchMeta(LaunchMeta{
+		SessionName: "ghostty-mode",
+		Agent:       "claude",
+		Cwd:         "/tmp",
+		Prompt:      "secret-token-abc",
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	path := filepath.Join(home, ".deckpilot", "launch-meta", "ghostty-mode.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if runtime.GOOS == "windows" {
+		// NTFS doesn't honor the Unix mode bits — Go reports
+		// 0o666 for owner-writable files. Just confirm the file
+		// is readable; the 0o600 intent in WriteLaunchMeta is
+		// what protects POSIX hosts and documents the policy.
+		if perm&0o400 == 0 {
+			t.Errorf("file should be owner-readable on Windows; got %o", perm)
+		}
+	} else {
+		if perm != 0o600 {
+			t.Errorf("expected mode 0o600, got %o", perm)
+		}
+	}
+}
+
+// TestWriteLaunchMeta_RedactedScrubsPrompt is issue #30 stage-2: when
+// Redacted=true the persisted JSON must NOT contain the prompt verbatim,
+// even though the in-memory LaunchMeta still carries it. Re-reading the
+// file should yield an empty Prompt and Redacted=true so snapshot v2
+// can branch on it.
+func TestWriteLaunchMeta_RedactedScrubsPrompt(t *testing.T) {
+	home := withMetaHome(t)
+	secret := "sk-do-not-leak-this-token-1234567890"
+	if err := WriteLaunchMeta(LaunchMeta{
+		SessionName: "ghostty-redacted",
+		Agent:       "claude",
+		Cwd:         "/work",
+		Prompt:      secret,
+		Redacted:    true,
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	path := filepath.Join(home, ".deckpilot", "launch-meta", "ghostty-redacted.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(body), secret) {
+		t.Fatalf("redacted JSON leaked the prompt:\n%s", body)
+	}
+	if !strings.Contains(string(body), `"redacted": true`) {
+		t.Errorf("expected redacted flag in JSON; got:\n%s", body)
+	}
+	got, ok, err := ReadLaunchMeta("ghostty-redacted")
+	if err != nil || !ok {
+		t.Fatalf("read back: ok=%v err=%v", ok, err)
+	}
+	if got.Prompt != "" {
+		t.Errorf("Prompt must be empty after redacted round-trip, got %q", got.Prompt)
+	}
+	if !got.Redacted {
+		t.Errorf("Redacted flag lost on round-trip")
+	}
+}
+
+// TestParseLaunchArgs covers the args parser carved out of Launch:
+// agent + prompt collection, --cwd capture, --no-meta-prompt flag
+// detection, and the missing-prompt error. ParseLaunchArgs is the
+// only path Launch uses to interpret argv, so pinning it here keeps
+// the redaction flag from regressing into a string token in the
+// prompt body.
+func TestParseLaunchArgs(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           []string
+		defaultCwd     string
+		wantAgent      string
+		wantPrompt     string
+		wantCwd        string
+		wantNoMeta     bool
+		wantErrSubstr  string
+	}{
+		{
+			name:       "basic",
+			args:       []string{"claude", "hello", "world"},
+			defaultCwd: "/d",
+			wantAgent:  "claude",
+			wantPrompt: "hello world",
+			wantCwd:    "/d",
+		},
+		{
+			name:       "with cwd",
+			args:       []string{"gemini", "fix", "bug", "--cwd", "/work"},
+			defaultCwd: "/d",
+			wantAgent:  "gemini",
+			wantPrompt: "fix bug",
+			wantCwd:    "/work",
+		},
+		{
+			name:       "no-meta-prompt before prompt",
+			args:       []string{"claude", "--no-meta-prompt", "secret-prompt"},
+			defaultCwd: "/d",
+			wantAgent:  "claude",
+			wantPrompt: "secret-prompt",
+			wantCwd:    "/d",
+			wantNoMeta: true,
+		},
+		{
+			name:       "no-meta-prompt mixed with cwd",
+			args:       []string{"claude", "do", "thing", "--no-meta-prompt", "--cwd", "/w"},
+			defaultCwd: "/d",
+			wantAgent:  "claude",
+			wantPrompt: "do thing",
+			wantCwd:    "/w",
+			wantNoMeta: true,
+		},
+		{
+			name:          "missing prompt",
+			args:          []string{"claude"},
+			defaultCwd:    "/d",
+			wantErrSubstr: "usage:",
+		},
+		{
+			name:          "cwd without value",
+			args:          []string{"claude", "hi", "--cwd"},
+			defaultCwd:    "/d",
+			wantErrSubstr: "--cwd requires",
+		},
+		{
+			name:          "no args",
+			args:          nil,
+			defaultCwd:    "/d",
+			wantErrSubstr: "usage:",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, errMsg := ParseLaunchArgs(c.args, c.defaultCwd)
+			if c.wantErrSubstr != "" {
+				if !strings.Contains(errMsg, c.wantErrSubstr) {
+					t.Fatalf("err=%q, want substring %q", errMsg, c.wantErrSubstr)
+				}
+				return
+			}
+			if errMsg != "" {
+				t.Fatalf("unexpected err: %s", errMsg)
+			}
+			if got.AgentName != c.wantAgent {
+				t.Errorf("AgentName=%q want %q", got.AgentName, c.wantAgent)
+			}
+			if got.Prompt != c.wantPrompt {
+				t.Errorf("Prompt=%q want %q", got.Prompt, c.wantPrompt)
+			}
+			if got.Cwd != c.wantCwd {
+				t.Errorf("Cwd=%q want %q", got.Cwd, c.wantCwd)
+			}
+			if got.NoMetaPrompt != c.wantNoMeta {
+				t.Errorf("NoMetaPrompt=%v want %v", got.NoMetaPrompt, c.wantNoMeta)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #30. Stops `deckpilot launch <agent> \"<prompt>\"` from leaving
the prompt readable on disk for 3 days.

- **Stage 1 (unconditional)**: `~/.deckpilot/launch-meta/<session>.json`
  and `~/.deckpilot/hang-dumps/<ts>-<session>.log` are now written with
  mode `0o600` instead of `0o644`. POSIX hosts get owner-only access;
  on Windows the bits are intent rather than enforcement (NTFS does not
  derive ACLs from Unix mode), but the policy is documented and tests
  assert the mode on POSIX.
- **Stage 2 (opt-in)**: `deckpilot launch --no-meta-prompt <agent>
  \"<prompt>\"` suppresses prompt persistence entirely. The
  `LaunchMeta` struct gains a `Redacted bool` flag; when set,
  `WriteLaunchMeta` scrubs the `Prompt` field before write and the
  hang-detect snapshot emits `# original_prompt: <redacted>` plus a
  `# resume_command:` whose prompt argument is the placeholder
  `<REDACTED — supply manually>`. The operator must re-type the secret
  to respawn.
- Args parsing is extracted into `ParseLaunchArgs` so the new flag is
  covered by table-driven tests without going through `os.Exit`.
- README.md / README.ja.md updated with the prompt-persistence note and
  the `--no-meta-prompt` example.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1 -race` (all green)
- [x] New tests pin: 0o600 mode on launch-meta + hang-dump (POSIX-strict,
      Windows owner-readable smoke), Redacted=true scrubs prompt from
      JSON and snapshot, `ParseLaunchArgs` table covers `--cwd`,
      `--no-meta-prompt`, missing prompt, missing `--cwd` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)