### PR TITLE
feat(daemon): persist idle hooks across daemon restarts (#31)

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -19,6 +19,14 @@ import (
 // Both contain only sanitized session-name-derived filenames, so
 // blanket age-based GC is safe; nothing in either tree is intended to
 // be edited by hand.
+//
+// NOT swept here: ~/.deckpilot/idle-hooks/ (issue #31). Idle hooks
+// are user configuration registered via `deckpilot notify add`.
+// Age-based GC would silently delete hooks the operator created
+// weeks ago, and liveness GC has no bound session to key off of.
+// Lifecycle for that directory is exclusively `deckpilot notify
+// remove` (or hand-deleting files). Do NOT add idleHooksDir() to the
+// totals slice below.
 func Cleanup(args []string) {
 	maxAge := 3 * 24 * time.Hour
 	dryRun := false

--- a/cmd/paths.go
+++ b/cmd/paths.go
@@ -38,6 +38,18 @@ func hangDumpsDir() string { return filepath.Join(deckpilotHomeDir(), "hang-dump
 // `deckpilot cleanup` sweeps under the launch-meta label.
 func launchMetaDir() string { return filepath.Join(deckpilotHomeDir(), "launch-meta") }
 
+// idleHooksDir is where `deckpilot notify add` persists user-configured
+// idle hooks so they survive daemon restarts (issue #31). NOT swept by
+// `deckpilot cleanup` — these are user configuration, not artefacts:
+// neither age-based GC (operator may reasonably leave a hook in place
+// for weeks) nor liveness GC (no bound session) is appropriate. The
+// daemon owns add/remove via IPC; this is the cmd-side view.
+//
+// Note: daemon/idle_hooks_persist.go has its own copy of this path
+// resolution to avoid a daemon→cmd import cycle (cmd already imports
+// daemon for IPC helpers). Keep the two implementations aligned.
+func idleHooksDir() string { return filepath.Join(deckpilotHomeDir(), "idle-hooks") }
+
 // sanitizeFilename replaces characters that Windows / POSIX
 // filesystems reject in path segments. Also collapses to "unnamed"
 // when the input would yield an empty filename.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,9 +43,13 @@ type Daemon struct {
 	WSPort      int                      // WebSocket control port (default 8080)
 }
 
-// New creates a new Daemon instance.
+// New creates a new Daemon instance. Idle hooks persisted under
+// ~/.deckpilot/idle-hooks/ are restored into the in-memory slice so
+// `deckpilot notify add ...` survives daemon restarts (issue #31).
+// Load failures are non-fatal: a missing directory returns an empty
+// slice, and individual unparseable files are skipped with a warning.
 func New() *Daemon {
-	return &Daemon{
+	d := &Daemon{
 		sessions:    make(map[string]string),
 		wsURLs:      make(map[string]string),
 		appRuntimes: make(map[string]string),
@@ -55,6 +59,11 @@ func New() *Daemon {
 		idleHooks:   make([]IdleHook, 0),
 		WSPort:      8080, // Default port
 	}
+	if loaded := loadIdleHooks(); len(loaded) > 0 {
+		d.idleHooks = loaded
+		log.Printf("daemon: restored %d idle hook(s) from %s", len(loaded), idleHooksDir())
+	}
+	return d
 }
 
 // Run starts the daemon: auto-discovers sessions, starts watchers, and
@@ -326,20 +335,40 @@ func pingDaemon() bool {
 	return string(buf[:n]) == "PONG\n"
 }
 
-// AddIdleHook adds a hook to be executed when sessions become idle
+// AddIdleHook adds a hook to be executed when sessions become idle.
+// Generates an ID if the caller didn't supply one and best-effort
+// persists the hook to ~/.deckpilot/idle-hooks/<id>.json so it
+// survives daemon restarts (issue #31). Persistence failures are
+// logged but never block the in-memory append: if the disk is
+// read-only the hook still fires for the lifetime of this daemon.
+//
+// Order: in-memory append happens first, then file write. If the
+// write fails the in-memory state is the source of truth — there is
+// no rollback. This matches the wider daemon contract that hooks live
+// in d.idleHooks at fire time.
 func (d *Daemon) AddIdleHook(hook IdleHook) {
+	if hook.ID == "" {
+		hook.ID = generateHookID()
+	}
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	d.idleHooks = append(d.idleHooks, hook)
-	log.Printf("daemon: added idle hook type=%s", hook.Type)
+	d.mu.Unlock()
+	if err := writeIdleHookFile(hook); err != nil {
+		log.Printf("daemon: idle-hook persist warning (continuing in-memory): %v", err)
+	}
+	log.Printf("daemon: added idle hook id=%s type=%s", hook.ID, hook.Type)
 }
 
-// RemoveIdleHooks removes all idle hooks
+// RemoveIdleHooks removes all idle hooks from memory and disk.
+// In-memory clear happens first; the file sweep is best-effort and
+// logs per-file failures without surfacing them — the IPC contract
+// only promises that the in-memory state has been wiped.
 func (d *Daemon) RemoveIdleHooks() {
 	d.mu.Lock()
-	defer d.mu.Unlock()
 	d.idleHooks = make([]IdleHook, 0)
-	log.Printf("daemon: removed all idle hooks")
+	d.mu.Unlock()
+	removeAllIdleHookFiles()
+	log.Printf("daemon: removed all idle hooks (memory + disk)")
 }
 
 // ListIdleHooks returns a copy of current idle hooks
@@ -363,6 +392,7 @@ func (d *Daemon) executeStatusHooks(notification BufferNotification) {
 	d.mu.Lock()
 	toFire := make([]IdleHook, 0, len(d.idleHooks))
 	remaining := make([]IdleHook, 0, len(d.idleHooks))
+	prunedIDs := make([]string, 0)
 	for _, hook := range d.idleHooks {
 		if hook.SessionFilter != "" && hook.SessionFilter != notification.SessionName {
 			remaining = append(remaining, hook)
@@ -371,6 +401,9 @@ func (d *Daemon) executeStatusHooks(notification BufferNotification) {
 		toFire = append(toFire, hook)
 		if !hook.OneTime {
 			remaining = append(remaining, hook)
+		} else {
+			// Capture IDs for sidecar-file cleanup outside the mutex.
+			prunedIDs = append(prunedIDs, hook.ID)
 		}
 	}
 	prunedOneTime := len(d.idleHooks) - len(remaining)
@@ -379,6 +412,20 @@ func (d *Daemon) executeStatusHooks(notification BufferNotification) {
 
 	if prunedOneTime > 0 {
 		log.Printf("daemon: pruned %d one-time hook(s) atomically before fire", prunedOneTime)
+		// Persistence cleanup mirrors the in-memory prune. Outside the
+		// mutex on purpose: file I/O must not block other IPC handlers,
+		// and the in-memory state has already been updated atomically
+		// so a crash between prune and unlink only leaks a stale file
+		// that loadIdleHooks will resurrect on next boot — acceptable
+		// trade for not extending mutex scope across disk I/O.
+		for _, id := range prunedIDs {
+			if id == "" {
+				continue
+			}
+			if err := removeIdleHookFile(id); err != nil {
+				log.Printf("daemon: idle-hook file cleanup warning: %v", err)
+			}
+		}
 	}
 
 	for _, hook := range toFire {

--- a/daemon/idle_hooks_persist.go
+++ b/daemon/idle_hooks_persist.go
@@ -1,0 +1,175 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Idle hooks are persisted to disk so they survive daemon restarts.
+// Storage layout mirrors launch-meta (cmd/launchmeta.go): one JSON file
+// per hook under ~/.deckpilot/idle-hooks/<id>.json.
+//
+// Why a sidecar JSON tree instead of widening the IPC surface:
+//   - The daemon's idleHooks slice is in-memory; restarts wipe it,
+//     forcing the operator to re-run `deckpilot notify add ...` each
+//     time the daemon comes back up. That defeats the whole point of
+//     hooks as a long-lived configuration.
+//   - The launch-meta refactor (commit 2f7b79a) already proved the
+//     pattern works without changing IPC: callers keep the existing
+//     HOOK / HOOK_LIST envelope, and the daemon just learned to load
+//     and write a directory at boot / mutation time.
+//
+// Package boundary note: cmd/paths.go has its own deckpilotHomeDir()
+// for CLI-side path resolution, but having daemon import cmd would
+// create a cycle (cmd already imports daemon for IPC helpers). The
+// daemon therefore keeps its own UserHomeDir seam below; the small
+// duplication is acceptable to preserve the package boundary.
+
+// daemonUserHome is the test seam for the daemon's home-dir lookup.
+// Independent from cmd/paths.go's deckpilotUserHome on purpose: the
+// two packages must not import each other.
+var daemonUserHome = os.UserHomeDir
+
+// idleHooksDir returns ~/.deckpilot/idle-hooks (or the %TEMP% fallback
+// if HOME / USERPROFILE are unresolvable, matching cmd/paths.go's
+// deckpilotHomeDir() behavior).
+func idleHooksDir() string {
+	home, err := daemonUserHome()
+	if err == nil {
+		return filepath.Join(home, ".deckpilot", "idle-hooks")
+	}
+	return filepath.Join(os.TempDir(), "deckpilot", "idle-hooks")
+}
+
+// generateHookID returns a unique hook ID. Uses timestamp (ns) plus
+// 8 random bytes so concurrent AddIdleHook calls cannot collide even
+// if the wall-clock resolution is coarse on Windows.
+func generateHookID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to ns timestamp alone — never block AddIdleHook on
+		// PRNG failure (which on Windows is essentially impossible but
+		// must not panic the daemon either).
+		return fmt.Sprintf("hook-%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("hook-%d-%s", time.Now().UnixNano(), hex.EncodeToString(b[:]))
+}
+
+// idleHookPath returns the on-disk path for the given hook id.
+func idleHookPath(id string) string {
+	return filepath.Join(idleHooksDir(), id+".json")
+}
+
+// writeIdleHookFile persists a single hook. Best-effort: returns the
+// error so callers can log a warning, but AddIdleHook must not fail
+// just because the disk is read-only.
+func writeIdleHookFile(hook IdleHook) error {
+	if hook.ID == "" {
+		return fmt.Errorf("writeIdleHookFile: hook missing ID")
+	}
+	dir := idleHooksDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("idle-hook mkdir: %w", err)
+	}
+	body, err := json.MarshalIndent(hook, "", "  ")
+	if err != nil {
+		return fmt.Errorf("idle-hook marshal: %w", err)
+	}
+	path := idleHookPath(hook.ID)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return fmt.Errorf("idle-hook write %s: %w", path, err)
+	}
+	return nil
+}
+
+// removeIdleHookFile deletes the on-disk record for hook id. Missing
+// files are not an error — the in-memory state is the source of truth
+// at fire time, the file is just persistence.
+func removeIdleHookFile(id string) error {
+	if id == "" {
+		return nil
+	}
+	path := idleHookPath(id)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("idle-hook remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// removeAllIdleHookFiles wipes every persisted hook in idleHooksDir.
+// Used by RemoveIdleHooks. A missing directory is treated as a no-op
+// (matches the "first-call-on-fresh-install" pattern from cleanup.go).
+// Per-file errors are logged and skipped — one corrupt file must not
+// prevent the rest of the wipe.
+func removeAllIdleHookFiles() {
+	dir := idleHooksDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		log.Printf("daemon: idle-hook list dir %s: %v", dir, err)
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if err := os.Remove(path); err != nil {
+			log.Printf("daemon: idle-hook remove %s: %v", path, err)
+		}
+	}
+}
+
+// loadIdleHooks reads every *.json file under idleHooksDir and returns
+// the hooks. Best-effort: a missing directory yields an empty slice
+// with no error, and individual parse failures are skipped with a
+// warning so the daemon can always start.
+func loadIdleHooks() []IdleHook {
+	dir := idleHooksDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("daemon: idle-hook load dir %s: %v", dir, err)
+		}
+		return nil
+	}
+	out := make([]IdleHook, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) != ".json" {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("daemon: idle-hook read %s: %v", path, err)
+			continue
+		}
+		var hook IdleHook
+		if err := json.Unmarshal(body, &hook); err != nil {
+			log.Printf("daemon: idle-hook parse %s: %v (skipping)", path, err)
+			continue
+		}
+		// Backfill ID from filename if the file was hand-edited and the
+		// embedded ID got lost.
+		if hook.ID == "" {
+			hook.ID = name[:len(name)-len(".json")]
+		}
+		out = append(out, hook)
+	}
+	return out
+}

--- a/daemon/idle_hooks_persist_test.go
+++ b/daemon/idle_hooks_persist_test.go
@@ -1,0 +1,240 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// withIdleHooksHome replaces the daemon's UserHomeDir seam with a temp
+// dir for the duration of the test, so the persistence tree is fully
+// isolated. Mirrors cmd/launchmeta_test.go's withMetaHome.
+func withIdleHooksHome(t *testing.T) string {
+	t.Helper()
+	tempHome := t.TempDir()
+	old := daemonUserHome
+	t.Cleanup(func() { daemonUserHome = old })
+	daemonUserHome = func() (string, error) { return tempHome, nil }
+	return tempHome
+}
+
+// TestAddIdleHook_PersistsToFile pins that AddIdleHook writes a JSON
+// file under ~/.deckpilot/idle-hooks/<id>.json — the core promise of
+// issue #31.
+func TestAddIdleHook_PersistsToFile(t *testing.T) {
+	home := withIdleHooksHome(t)
+
+	d := New()
+	hook := IdleHook{
+		Type:          "stdout",
+		Message:       "hello",
+		SessionFilter: "ghostty-1",
+	}
+	d.AddIdleHook(hook)
+
+	hooks := d.ListIdleHooks()
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 in-memory hook, got %d", len(hooks))
+	}
+	id := hooks[0].ID
+	if id == "" {
+		t.Fatal("AddIdleHook must assign an ID for persistence")
+	}
+
+	path := filepath.Join(home, ".deckpilot", "idle-hooks", id+".json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected sidecar JSON at %s, err=%v", path, err)
+	}
+}
+
+// TestNew_RestoresIdleHooksFromDisk pins the daemon-restart invariant.
+// AddIdleHook on one daemon instance, then a fresh New() must rehydrate
+// the same hook from disk. Without this, `deckpilot notify add ...`
+// silently dies on every restart.
+func TestNew_RestoresIdleHooksFromDisk(t *testing.T) {
+	withIdleHooksHome(t)
+
+	d1 := New()
+	d1.AddIdleHook(IdleHook{
+		Type:          "callback",
+		SessionFilter: "target",
+		// Concrete CallbackSession so the round-trip checks more than just Type.
+		CallbackSession: "caller",
+		OneTime:         false,
+	})
+
+	// Simulate a daemon restart: discard d1, build a fresh Daemon.
+	d2 := New()
+	got := d2.ListIdleHooks()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 restored hook, got %d", len(got))
+	}
+	if got[0].Type != "callback" || got[0].SessionFilter != "target" || got[0].CallbackSession != "caller" {
+		t.Errorf("restored hook lost fields: %+v", got[0])
+	}
+	if got[0].ID == "" {
+		t.Error("restored hook should keep its ID")
+	}
+}
+
+// TestRemoveIdleHooks_DeletesAllFiles pins that RemoveIdleHooks wipes
+// the on-disk tree as well as the in-memory slice. Otherwise `notify
+// remove` lies — the hooks come back next restart.
+func TestRemoveIdleHooks_DeletesAllFiles(t *testing.T) {
+	home := withIdleHooksHome(t)
+
+	d := New()
+	d.AddIdleHook(IdleHook{Type: "stdout", Message: "a"})
+	d.AddIdleHook(IdleHook{Type: "stdout", Message: "b"})
+
+	dir := filepath.Join(home, ".deckpilot", "idle-hooks")
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 2 {
+		t.Fatalf("setup: expected 2 sidecar files, got %d", len(entries))
+	}
+
+	d.RemoveIdleHooks()
+
+	if hooks := d.ListIdleHooks(); len(hooks) != 0 {
+		t.Errorf("in-memory hooks not cleared: %d remain", len(hooks))
+	}
+	entries, _ = os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("sidecar files not cleared: %d remain", len(entries))
+	}
+}
+
+// TestExecuteStatusHooks_OneTimeFiresAndDeletesFile pins the persistence
+// half of the OneTime contract: when a one-time hook fires, both the
+// in-memory entry AND the sidecar JSON must vanish, otherwise the next
+// daemon restart will resurrect the already-spent hook and re-fire it.
+func TestExecuteStatusHooks_OneTimeFiresAndDeletesFile(t *testing.T) {
+	home := withIdleHooksHome(t)
+
+	d := New()
+	callerW := NewWatcher("caller", "p", "f", 1, "", nil)
+	d.mu.Lock()
+	d.watchers["caller"] = callerW
+	d.mu.Unlock()
+
+	d.AddIdleHook(IdleHook{
+		Type:            "callback",
+		SessionFilter:   "target",
+		CallbackSession: "caller",
+		OneTime:         true,
+	})
+
+	// Capture the pre-fire path so we can assert it disappears.
+	hooks := d.ListIdleHooks()
+	if len(hooks) != 1 {
+		t.Fatalf("setup: expected 1 hook, got %d", len(hooks))
+	}
+	preFirePath := filepath.Join(home, ".deckpilot", "idle-hooks", hooks[0].ID+".json")
+	if _, err := os.Stat(preFirePath); err != nil {
+		t.Fatalf("setup: sidecar must exist before fire, err=%v", err)
+	}
+
+	var got int32
+	stop := drainCaller(callerW, &got, nil, nil)
+	defer stop()
+
+	d.executeStatusHooks(newIdleNotification("target"))
+	time.Sleep(150 * time.Millisecond) // let the goroutine + cleanup land
+
+	if atomic.LoadInt32(&got) != 1 {
+		t.Errorf("expected 1 callback fire, got %d", got)
+	}
+	if hooks := d.ListIdleHooks(); len(hooks) != 0 {
+		t.Errorf("in-memory hook not pruned: %d remain", len(hooks))
+	}
+	if _, err := os.Stat(preFirePath); !os.IsNotExist(err) {
+		t.Errorf("sidecar must be deleted after one-time fire, stat err=%v", err)
+	}
+}
+
+// TestAddIdleHook_PersistFailureIsNonFatal pins that a read-only
+// idle-hooks dir does not crash AddIdleHook — the in-memory state
+// must still get the hook, only persistence is degraded. A panic here
+// would mean a misconfigured machine could brick `deckpilot notify`.
+func TestAddIdleHook_PersistFailureIsNonFatal(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// chmod-based read-only dir test is POSIX; on Windows we use a
+		// different strategy: force the home dir to point at a *file*
+		// path so MkdirAll fails. Same intent — write is impossible.
+	}
+	tempHome := t.TempDir()
+	// Make the home dir resolution point to a regular file so any
+	// MkdirAll under it fails on every platform.
+	blockedFile := filepath.Join(tempHome, "blocked")
+	if err := os.WriteFile(blockedFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	old := daemonUserHome
+	t.Cleanup(func() { daemonUserHome = old })
+	daemonUserHome = func() (string, error) { return blockedFile, nil }
+
+	d := New()
+	// AddIdleHook must not panic, even though MkdirAll(blockedFile/.deckpilot/idle-hooks)
+	// will fail because blockedFile is a regular file.
+	d.AddIdleHook(IdleHook{Type: "stdout", Message: "best-effort"})
+
+	if hooks := d.ListIdleHooks(); len(hooks) != 1 {
+		t.Fatalf("AddIdleHook lost the hook on persistence failure: %d in memory", len(hooks))
+	}
+}
+
+// TestNew_BadJSONFileSkipped pins that a corrupt sidecar JSON does not
+// stop the daemon from starting — the offending file is skipped with
+// a warning and the rest of the directory loads normally. Otherwise a
+// single hand-edited typo would brick the daemon's boot.
+func TestNew_BadJSONFileSkipped(t *testing.T) {
+	home := withIdleHooksHome(t)
+	dir := filepath.Join(home, ".deckpilot", "idle-hooks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "broken.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	good := IdleHook{ID: "good-1", Type: "stdout", Message: "ok"}
+	body := `{"id":"good-1","type":"stdout","message":"ok"}`
+	if err := os.WriteFile(filepath.Join(dir, "good-1.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New()
+	hooks := d.ListIdleHooks()
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 surviving hook, got %d (broken.json should be skipped)", len(hooks))
+	}
+	if hooks[0].ID != good.ID || hooks[0].Type != good.Type || hooks[0].Message != good.Message {
+		t.Errorf("good hook lost fields: %+v", hooks[0])
+	}
+}
+
+// TestLoadIdleHooks_BackfillsIDFromFilename pins that a file written
+// with no embedded ID still loads cleanly using the filename as the ID
+// fallback. Lets operators hand-author hooks without managing IDs.
+func TestLoadIdleHooks_BackfillsIDFromFilename(t *testing.T) {
+	home := withIdleHooksHome(t)
+	dir := filepath.Join(home, ".deckpilot", "idle-hooks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// JSON with no "id" key.
+	body := `{"type":"stdout","message":"hi"}`
+	if err := os.WriteFile(filepath.Join(dir, "hand-written.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := loadIdleHooks()
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(hooks))
+	}
+	if hooks[0].ID != "hand-written" {
+		t.Errorf("expected ID backfilled to filename stem, got %q", hooks[0].ID)
+	}
+}

--- a/daemon/testmain_test.go
+++ b/daemon/testmain_test.go
@@ -1,0 +1,29 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates the daemon test suite from the developer's real
+// ~/.deckpilot/idle-hooks tree. Issue #31 made daemon.New() load
+// persisted hooks from disk; without this isolation, every test that
+// calls New() (callback_test, hook_invariants_test, agent_to_agent_test,
+// wsserver_test, etc.) would inherit whatever hooks the dev machine
+// happens to have configured, breaking deterministic counts in
+// invariants like "OneTime fires exactly once".
+//
+// Tests that need to assert on persisted files specifically still call
+// withIdleHooksHome to swap to their own per-test temp dir on top of
+// this global override.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "deckpilot-daemon-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmp)
+	old := daemonUserHome
+	daemonUserHome = func() (string, error) { return tmp, nil }
+	defer func() { daemonUserHome = old }()
+	os.Exit(m.Run())
+}

--- a/daemon/types.go
+++ b/daemon/types.go
@@ -8,6 +8,7 @@ package daemon
 
 // IdleHook defines an action to execute when a session becomes idle.
 type IdleHook struct {
+	ID              string            `json:"id,omitempty"`     // stable identifier; used as the on-disk filename for persistence
 	Type            string            `json:"type"`             // "http", "stdout", "send", "callback"
 	URL             string            `json:"url"`              // for "http" type
 	Method          string            `json:"method"`           // for "http" type (default: POST)


### PR DESCRIPTION
## Summary
- `deckpilot notify add` now writes each hook to `~/.deckpilot/idle-hooks/<id>.json` so the daemon can restore them after restart (mirrors the launch-meta sidecar pattern from 2f7b79a).
- `daemon.New()` rehydrates the in-memory `idleHooks` slice from disk; bad JSON files are skipped with a warning so a single typo can never block boot.
- `executeStatusHooks` deletes the sidecar file when a `OneTime` hook fires, preserving the existing "prune before fire" invariant locked by `TestHookInvariant_OneTimeFiresExactlyOnce`.
- `RemoveIdleHooks` wipes both memory and disk.
- IPC wire format (HOOK / HOOK_LIST) is unchanged.
- `deckpilot cleanup` explicitly skips `idle-hooks/` — user config, not artefact: age/liveness GC are both wrong.

## Notes
- File I/O is best-effort everywhere (warn-only) so a read-only home dir cannot crash AddIdleHook.
- Daemon test suite gains a `TestMain` that swaps `daemonUserHome` to a temp dir, so existing hook invariant / callback / wsserver / agent_to_agent tests don't pick up the developer's real `~/.deckpilot/idle-hooks/` (which used to be a no-op directory; restoring 7 hooks during `New()` now would have thrown off counts).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1 -race`
- [x] `TestHookInvariant_OneTimeFiresExactlyOnce` still passes (one-time prune-before-fire invariant intact)
- [x] New tests cover: persist-on-add, restore-on-new, one-time fire deletes file, RemoveIdleHooks wipes disk, persist failure non-fatal, bad JSON skipped, ID backfill from filename

Closes #31